### PR TITLE
Add ability to force-disable dropframe when generating an EDL

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -258,6 +258,7 @@ class Adapter(plugins.PythonPlugin):
         **adapter_argument_map
     ):
         """Call the write_to_string function on this adapter."""
+        print(f"Called write_to_string with args: {input_otio}, {hook_function_argument_map}, {adapter_argument_map}")
 
         hook_function_argument_map = copy.deepcopy(
             hook_function_argument_map or {}

--- a/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
@@ -131,11 +131,13 @@ class PythonPlugin(core.SerializableObject):
         if not self._module:
             self._module = self._imported_module("adapters")
 
+        print(f"Retrieved plugin module: {self._module}")
         return self._module
 
     def _execute_function(self, func_name, **kwargs):
         """Execute func_name on this adapter with error checking."""
 
+        print(f"Invoking plugin function: {func_name} with args: {kwargs}")
         # collects the error handling into a common place.
         if not hasattr(self.module(), func_name):
             raise exceptions.AdapterDoesntSupportFunctionError(


### PR DESCRIPTION
Background
to_timecode, if not instructed otherwise, will use "dropframe" notation if the frame rate looks like a dropframe (ex: 29.97). Some customers use partial-frame rates, but do _not_ use dropframe. Therefore, we need the ability to tell the OTIO EDL exporter about cases where dropframe should be disabled, regardless of framerate.

Changes
Add "force_disable_sources_dropframe" as an argument to EDL exporter (defaults to false) and apply all the way down to the EDL line writer. Add some basic logs as well.

Tests
pip3 install the package and run this code
```
import opentimelineio as otio
x=otio.opentime.RationalTime(value=0, rate=29.97002997002997)
y=otio.opentime.RationalTime(value=3495, rate=29.97002997002997)
range=otio.opentime.TimeRange(x, y)
clip=otio.schema.Clip(name="source.mov", media_reference=None, source_range=range)
timeline = otio.schema.Timeline(name="test_tl", global_start_time=otio.opentime.RationalTime(0, 29.97002997002997))
track = otio.schema.Track()
track.append(clip)
timeline.tracks.append(track)
otio.adapters.write_to_string(timeline, "cmx_3600", rate=29.97002997002997, force_disable_sources_dropframe=True)
```
```
'TITLE: test_tl\n\n001  source   V     C        00:00:00:00 00:01:56:15 00:00:00;00 00:01:56;17\n* FROM CLIP NAME:  source.mov\n* OTIO TRUNCATED REEL NAME FROM: source.mov\n'
```
Note the NDF notation on the source and the DF notation on the reference.

Followup
DeweyEngine side changes to use this
OTIO Logger