### PR TITLE
Extend force-disable dropframe capability to include Reference timeline

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1058,7 +1058,7 @@ class Event:
         line = EventLine(
             kind, rate, reel=reel,
             force_disable_sources_dropframe=force_disable_sources_dropframe,
-            force_disable_target_dropframe=force_disable_target_dropframe
+            force_disable_target_dropframe=force_disable_target_dropframe,
         )
 
         line.source_in = clip.source_range.start_time

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -23,6 +23,37 @@ from .. import (
     opentime,
 )
 
+#############################################################################################
+# Customization to help with writing timecodes while keeping dropframe vs nondropframe in mind
+# See https://en.wikipedia.org/wiki/SMPTE_timecode#Drop-frame_timecode
+#############################################################################################
+
+class ITimeCodeWriter:
+    def write_timecode(self, rationalTime: opentime.RationalTime):
+        pass
+
+class ForceDropFrameTimeCodeWriter(ITimeCodeWriter):
+    def __init__(self, rate):
+        self.rate = rate
+
+    def write_timecode(self, rationalTime: opentime.RationalTime):
+        return opentime.to_timecode(rationalTime, self.rate, drop_frame=0)
+
+class InferredDropFrameTimeCodeWriter(ITimeCodeWriter):
+    def __init__(self, rate):
+        self.rate = rate
+
+    def write_timecode(self, rationalTime: opentime.RationalTime):
+        return opentime.to_timecode(rationalTime, self.rate)
+
+class TimeCodeWriterFactory:
+    @staticmethod
+    def create_timecode_provider(rate, force_disable_dropframe: bool = False) -> ITimeCodeWriter:
+        if force_disable_dropframe:
+            return ForceDropFrameTimeCodeWriter(rate)
+        return InferredDropFrameTimeCodeWriter(rate)
+
+#############################################################################################
 
 class EDLParseError(exceptions.OTIOError):
     pass
@@ -798,11 +829,17 @@ def write_to_string(
     rate=None,
     style='avid',
     reelname_len=8,
-    force_disable_sources_dropframe=False
+    force_disable_sources_dropframe=False,
+    force_disable_target_dropframe=False,
 ):
     # TODO: We should have convenience functions in Timeline for this?
     # also only works for a single video track at the moment
-    print(f"Invoked cmx_3600 write_to_string with arguments: {input_otio}, {rate}, {style}, {reelname_len}, {force_disable_sources_dropframe}")
+    print(
+        "Invoked cmx_3600 write_to_string with arguments: " +
+        f"{input_otio}, {rate}, {style}, {reelname_len}, " +
+        f"{force_disable_sources_dropframe}, " +
+        f"{force_disable_target_dropframe}"
+    )
 
     video_tracks = [t for t in input_otio.tracks
                     if t.kind == schema.TrackKind.Video and t.enabled]
@@ -834,19 +871,25 @@ def write_to_string(
         rate=rate or input_otio.tracks[0].duration().rate,
         style=style,
         reelname_len=reelname_len,
-        force_disable_sources_dropframe=force_disable_sources_dropframe
+        force_disable_sources_dropframe=force_disable_sources_dropframe,
+        force_disable_target_dropframe=force_disable_target_dropframe,
     )
 
     return writer.get_content_for_track_at_index(0, title=input_otio.name)
 
 
 class EDLWriter:
-    def __init__(self, tracks, rate, style, reelname_len=8, force_disable_sources_dropframe=False):
+    def __init__(self,
+        tracks, rate, style, reelname_len=8,
+        force_disable_sources_dropframe=False,
+        force_disable_target_dropframe=False,
+    ):
         self._tracks = tracks
         self._rate = rate
         self._style = style
         self._reelname_len = reelname_len
         self._force_disable_sources_dropframe = force_disable_sources_dropframe
+        self._force_disable_target_dropframe = force_disable_target_dropframe
 
         if style not in VALID_EDL_STYLES:
             raise exceptions.NotSupportedError(
@@ -919,6 +962,7 @@ class EDLWriter:
                         self._style,
                         self._reelname_len,
                         self._force_disable_sources_dropframe,
+                        self._force_disable_target_dropframe,
                     )
                 )
             elif isinstance(child, schema.Clip):
@@ -932,6 +976,7 @@ class EDLWriter:
                             self._style,
                             self._reelname_len,
                             self._force_disable_sources_dropframe,
+                            self._force_disable_target_dropframe,
                         )
                     )
                 else:
@@ -989,7 +1034,8 @@ class Event:
         rate,
         style,
         reelname_len,
-        force_disable_sources_dropframe
+        force_disable_sources_dropframe,
+        force_disable_target_dropframe,
     ):
 
         # Premiere style uses AX for the reel name
@@ -1069,11 +1115,16 @@ class DissolveEvent:
         style,
         reelname_len,
         force_disable_sources_dropframe,
+        force_disable_target_dropframe,
     ):
         # Note: We don't make the A-Side event line here as it is represented
         # by its own event (edit number).
 
-        cut_line = EventLine(kind, rate, force_disable_sources_dropframe=force_disable_sources_dropframe)
+        cut_line = EventLine(
+            kind, rate,
+            force_disable_sources_dropframe=force_disable_sources_dropframe,
+            force_disable_target_dropframe=force_disable_target_dropframe,
+        )
 
         if a_side_event:
             cut_line.reel = a_side_event.reel
@@ -1103,6 +1154,7 @@ class DissolveEvent:
             rate,
             reel=_reel_from_clip(b_side_clip, reelname_len),
             force_disable_sources_dropframe=force_disable_sources_dropframe,
+            force_disable_target_dropframe=force_disable_target_dropframe,
         )
         dslve_line.source_in = b_side_clip.source_range.start_time
         dslve_line.source_out = b_side_clip.source_range.end_time_exclusive()
@@ -1176,9 +1228,12 @@ class DissolveEvent:
 
         return "\n".join(lines)
 
-
 class EventLine:
-    def __init__(self, kind, rate, reel='AX', force_disable_sources_dropframe=False):
+    def __init__(self,
+        kind, rate, reel='AX',
+        force_disable_sources_dropframe=False,
+        force_disable_target_dropframe=False,
+    ):
         self.reel = reel
         self._kind = 'V' if kind == schema.TrackKind.Video else 'A'
         self._rate = rate
@@ -1190,17 +1245,18 @@ class EventLine:
 
         self.dissolve_length = opentime.RationalTime(0.0, rate)
 
-        self.force_disable_sources_dropframe = force_disable_sources_dropframe
+        self.source_timecode_provider = TimeCodeWriterFactory.create_timecode_provider(rate, force_disable_sources_dropframe)
+        self.target_timecode_provider = TimeCodeWriterFactory.create_timecode_provider(rate, force_disable_target_dropframe)
 
     def to_edl_format(self, edit_number):
         ser = {
             'edit': edit_number,
             'reel': self.reel,
             'kind': self._kind,
-            'src_in': self._to_timecode_handle_dropframe(self.source_in),
-            'src_out': self._to_timecode_handle_dropframe(self.source_out),
-            'rec_in': opentime.to_timecode(self.record_in, self._rate),
-            'rec_out': opentime.to_timecode(self.record_out, self._rate),
+            'src_in': self.source_timecode_provider.write_timecode(self.source_in),
+            'src_out': self.source_timecode_provider.write_timecode(self.source_out),
+            'rec_in': self.target_timecode_provider.write_timecode(self.record_in),
+            'rec_out': self.target_timecode_provider.write_timecode(self.record_out),
             'diss': int(
                 opentime.to_frames(self.dissolve_length, self._rate)
             ),
@@ -1215,12 +1271,6 @@ class EventLine:
 
     def is_dissolve(self):
         return self.dissolve_length.value > 0
-
-    def _to_timecode_handle_dropframe(self, rt):
-        if self.force_disable_sources_dropframe:
-            return opentime.to_timecode(rt, self._rate, drop_frame=0)
-        return opentime.to_timecode(rt, self._rate)
-
 
 def _generate_comment_lines(
     clip,


### PR DESCRIPTION
Background
In https://github.com/DeweyVision/OpenTimelineIO/pull/1, changes were introduced to prevent DF/NDF from being inferred based on framerate alone. That change only applied to the "Sources" column of an EDL.

Changes
Extend "disable dropframe" capability to the reference timeline, in cases where a fractional-framterate-ndf clip is supplied to the exporter.

Tests
New external unit tests validate the issue, test steps described in previous PR can also be used.

Followup
