### PR TITLE
Handle source framerates

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1035,13 +1035,14 @@ class Event:
                     line.source_in + opentime.RationalTime(value, rate))
         # use provided edl frame rate for record timecode conversions
         trimmed_range = clip.trimmed_range()
-        converted_range = opentime.TimeRange(opentime.RationalTime(trimmed_range.start_time.value, rate), opentime.RationalTime(trimmed_range.duration.value, rate))
+        converted_range = opentime.TimeRange(
+            trimmed_range.start_time, # start times can be calculated normally, but duration shouldn't be scaled
+            opentime.RationalTime(trimmed_range.duration.value, rate)
+            )
         range_in_timeline = clip.transformed_time_range(
             converted_range,
             tracks
         )
-#       range_in_timeline.start_time = opentime.RationalTime(range_in_timeline.start_time.value, rate)
-#       range_in_timeline.duration.rate = opentime.RationalTime(range_in_timeline.duration.value, rate)
         line.record_in = range_in_timeline.start_time
         line.record_out = range_in_timeline.end_time_exclusive()
         self.line = line

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1038,8 +1038,8 @@ class Event:
             clip.trimmed_range(),
             tracks
         )
-        range_in_timeline.start_time.rate = rate
-        range_in_timeline.duration.rate = rate
+        range_in_timeline.start_time = opentime.RationalTime(range_in_timeline.start_time.value, rate)
+        range_in_timeline.duration.rate = opentime.RationalTime(range_in_timeline.duration.value, rate)
         line.record_in = range_in_timeline.start_time
         line.record_out = range_in_timeline.end_time_exclusive()
         self.line = line

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1033,13 +1033,15 @@ class Event:
                 value = clip.trimmed_range().duration.value / timing_effect.time_scalar
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
-
+        # use provided edl frame rate for record timecode conversions
+        trimmed_range = clip.trimmed_range()
+        converted_range = opentime.TimeRange(opentime.RationalTime(trimmed_range.start_time.value, rate), opentime.RationalTime(trimmed_range.duration.value, rate))
         range_in_timeline = clip.transformed_time_range(
-            clip.trimmed_range(),
+            converted_range,
             tracks
         )
-        range_in_timeline.start_time = opentime.RationalTime(range_in_timeline.start_time.value, rate)
-        range_in_timeline.duration.rate = opentime.RationalTime(range_in_timeline.duration.value, rate)
+#       range_in_timeline.start_time = opentime.RationalTime(range_in_timeline.start_time.value, rate)
+#       range_in_timeline.duration.rate = opentime.RationalTime(range_in_timeline.duration.value, rate)
         line.record_in = range_in_timeline.start_time
         line.record_out = range_in_timeline.end_time_exclusive()
         self.line = line

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1038,6 +1038,8 @@ class Event:
             clip.trimmed_range(),
             tracks
         )
+        range_in_timeline.start_time.rate = rate
+        range_in_timeline.duration.rate = rate
         line.record_in = range_in_timeline.start_time
         line.record_out = range_in_timeline.end_time_exclusive()
         self.line = line

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1018,6 +1018,7 @@ class Event:
 
         line.source_in = clip.source_range.start_time
         line.source_out = clip.source_range.end_time_exclusive()
+        line.source_rate = clip.source_range.start_time.rate
 
         timing_effect = _relevant_timing_effect(clip)
 
@@ -1220,6 +1221,7 @@ class EventLine:
         self.reel = reel
         self._kind = 'V' if kind == schema.TrackKind.Video else 'A'
         self._rate = rate
+        self.source_rate = rate
 
         self.source_in = opentime.RationalTime(0.0, rate=rate)
         self.source_out = opentime.RationalTime(0.0, rate=rate)
@@ -1228,15 +1230,18 @@ class EventLine:
 
         self.dissolve_length = opentime.RationalTime(0.0, rate)
 
-        timecode_writer_factory = TimeCodeWriterFactory(rate)
-        self.source_timecode_provider = timecode_writer_factory.create_timecode_provider(
-            force_disable_sources_dropframe
-        )
-        self.target_timecode_provider = timecode_writer_factory.create_timecode_provider(
-            force_disable_target_dropframe
-        )
+        self._force_disable_sources_dropframe = force_disable_sources_dropframe
+        self._force_disable_target_dropframe = force_disable_target_dropframe
 
     def to_edl_format(self, edit_number):
+        source_timecode_writer_factory = TimeCodeWriterFactory(self.source_rate)
+        self.source_timecode_provider = source_timecode_writer_factory.create_timecode_provider(
+            self._force_disable_sources_dropframe
+        )
+        target_timecode_writer_factory = TimeCodeWriterFactory(self._rate)
+        self.target_timecode_provider = target_timecode_writer_factory.create_timecode_provider(
+            self._force_disable_target_dropframe
+        )
         ser = {
             'edit': edit_number,
             'reel': self.reel,


### PR DESCRIPTION
Updates CMX3600 EDL export to use the source frame rate when calculating source in/out timecodes, instead of only target.