### PR TITLE
Handle source framerates - fixed

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -882,7 +882,6 @@ class EDLWriter:
         track = self._tracks[idx]
 
         timeline_offset = track[0].source_range.duration if isinstance(track[0], schema.Gap) else opentime.RationalTime(0, self._rate)
-        offset_adjustment = timeline_offset.rescaled_to(self._rate).value - timeline_offset.value
 
         # Add a gap if the last child is a transition.
         if isinstance(track[-1], schema.Transition):
@@ -946,7 +945,7 @@ class EDLWriter:
                         self._reelname_len,
                         self._force_disable_sources_dropframe,
                         self._force_disable_target_dropframe,
-                        offset_adjustment,
+                        timeline_offset,
                     )
                 )
             elif isinstance(child, schema.Clip):
@@ -961,7 +960,7 @@ class EDLWriter:
                             self._reelname_len,
                             self._force_disable_sources_dropframe,
                             self._force_disable_target_dropframe,
-                            offset_adjustment,
+                            timeline_offset,
                         )
                     )
                 else:
@@ -1010,7 +1009,7 @@ class Event:
         reelname_len,
         force_disable_sources_dropframe,
         force_disable_target_dropframe,
-        offset_adjustment,
+        timeline_offset,
     ):
 
         # Premiere style uses AX for the reel name
@@ -1045,6 +1044,10 @@ class Event:
             trimmed_range,
             tracks
         )
+
+        clip_offset = timeline_offset.rescaled_to(clip.source_range.start_time.rate)
+        offset_adjustment = clip_offset.rescaled_to(29.97).value - clip_offset.value
+
         line.record_in = opentime.RationalTime(range_in_timeline.start_time.value + offset_adjustment, rate)
         line.record_out = opentime.RationalTime(range_in_timeline.end_time_exclusive().value + offset_adjustment, rate)
         self.line = line

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1039,17 +1039,22 @@ class Event:
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
 
+        # overwrite frame rates to prevent incorrect rescaling
+        clip.source_range = opentime.TimeRange(
+                start_time=opentime.RationalTime(clip.source_range.start_time.value, rate=rate),
+                duration=opentime.RationalTime(clip.source_range.duration.value, rate=rate))
+
         trimmed_range = clip.trimmed_range()
         range_in_timeline = clip.transformed_time_range(
             trimmed_range,
             tracks
         )
 
-        clip_offset = timeline_offset.rescaled_to(clip.source_range.start_time.rate)
-        offset_adjustment = clip_offset.rescaled_to(29.97).value - clip_offset.value
+        # clip_offset = timeline_offset.rescaled_to(clip.source_range.start_time.rate)
+        # offset_adjustment = clip_offset.rescaled_to(29.97).value - clip_offset.value
 
-        line.record_in = opentime.RationalTime(range_in_timeline.start_time.value + offset_adjustment, rate)
-        line.record_out = opentime.RationalTime(range_in_timeline.end_time_exclusive().value + offset_adjustment, rate)
+        line.record_in = range_in_timeline.start_time#opentime.RationalTime(range_in_timeline.start_time.value + offset_adjustment, rate)
+        line.record_out = range_in_timeline.end_time_exclusive()#opentime.RationalTime(range_in_timeline.end_time_exclusive().value + offset_adjustment, rate)
         self.line = line
 
         self.comments = _generate_comment_lines(

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -881,8 +881,6 @@ class EDLWriter:
     def get_content_for_track_at_index(self, idx, title):
         track = self._tracks[idx]
 
-        timeline_offset = track[0].source_range.duration if isinstance(track[0], schema.Gap) else opentime.RationalTime(0, self._rate)
-
         # Add a gap if the last child is a transition.
         if isinstance(track[-1], schema.Transition):
             gap = schema.Gap(
@@ -945,7 +943,6 @@ class EDLWriter:
                         self._reelname_len,
                         self._force_disable_sources_dropframe,
                         self._force_disable_target_dropframe,
-                        timeline_offset,
                     )
                 )
             elif isinstance(child, schema.Clip):
@@ -960,7 +957,6 @@ class EDLWriter:
                             self._reelname_len,
                             self._force_disable_sources_dropframe,
                             self._force_disable_target_dropframe,
-                            timeline_offset,
                         )
                     )
                 else:
@@ -1009,7 +1005,6 @@ class Event:
         reelname_len,
         force_disable_sources_dropframe,
         force_disable_target_dropframe,
-        timeline_offset,
     ):
 
         # Premiere style uses AX for the reel name
@@ -1050,11 +1045,8 @@ class Event:
             tracks
         )
 
-        # clip_offset = timeline_offset.rescaled_to(clip.source_range.start_time.rate)
-        # offset_adjustment = clip_offset.rescaled_to(29.97).value - clip_offset.value
-
-        line.record_in = range_in_timeline.start_time#opentime.RationalTime(range_in_timeline.start_time.value + offset_adjustment, rate)
-        line.record_out = range_in_timeline.end_time_exclusive()#opentime.RationalTime(range_in_timeline.end_time_exclusive().value + offset_adjustment, rate)
+        line.record_in = range_in_timeline.start_time
+        line.record_out = range_in_timeline.end_time_exclusive()
         self.line = line
 
         self.comments = _generate_comment_lines(
@@ -1104,7 +1096,6 @@ class DissolveEvent:
         reelname_len,
         force_disable_sources_dropframe,
         force_disable_target_dropframe,
-        offset_adjustment,
     ):
         # Note: We don't make the A-Side event line here as it is represented
         # by its own event (edit number).

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1034,12 +1034,12 @@ class Event:
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
 
-        # overwrite frame rates to prevent incorrect rescaling
-        trimmed_range = opentime.TimeRange(
+        trimmed_range_edl_framerate = opentime.TimeRange(
                 start_time=opentime.RationalTime(clip.trimmed_range().start_time.value, rate=rate),
-                duration=opentime.RationalTime(clip.trimmed_range().duration.value, rate=rate))
+                duration=opentime.RationalTime(clip.trimmed_range().duration.value, rate=rate)
+        )
         range_in_timeline = clip.transformed_time_range(
-            trimmed_range,
+            trimmed_range_edl_framerate,
             tracks
         )
 

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1035,11 +1035,9 @@ class Event:
                     line.source_in + opentime.RationalTime(value, rate))
 
         # overwrite frame rates to prevent incorrect rescaling
-        clip.source_range = opentime.TimeRange(
-                start_time=opentime.RationalTime(clip.source_range.start_time.value, rate=rate),
-                duration=opentime.RationalTime(clip.source_range.duration.value, rate=rate))
-
-        trimmed_range = clip.trimmed_range()
+        trimmed_range = opentime.TimeRange(
+                start_time=opentime.RationalTime(clip.trimmed_range().start_time.value, rate=rate),
+                duration=opentime.RationalTime(clip.trimmed_range().duration.value, rate=rate))
         range_in_timeline = clip.transformed_time_range(
             trimmed_range,
             tracks


### PR DESCRIPTION
Previously-added framerate feature [#4](https://github.com/DeweyVision/OpenTimelineIO/pull/4) was incomplete - it did not handle different framerates for tracks longer than 1 clip. Start timecodes were incorrectly calculated.

This PR fixes the calculation by avoiding extra automatic framerate rescaling, achieved by setting the source frame rate to the record frame rate when calculating record in/out timecodes.
