### PR TITLE
Hotfix: Handle framerates fix starttime

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1034,13 +1034,13 @@ class Event:
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
 
-        clip_with_timeline_framerate = copy.deepcopy(clip)
-        clip_with_timeline_framerate.source_range = opentime.TimeRange(
+
+        clip.source_range = opentime.TimeRange(
                 start_time=opentime.RationalTime(clip.source_range.start_time.value, rate=rate),
                 duration=opentime.RationalTime(clip.source_range.duration.value, rate=rate))
 
-        trimmed_range = clip_with_timeline_framerate.trimmed_range()
-        range_in_timeline = clip_with_timeline_framerate.transformed_time_range(
+        trimmed_range = clip.trimmed_range()
+        range_in_timeline = clip.transformed_time_range(
             trimmed_range,
             tracks
         )

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1034,13 +1034,13 @@ class Event:
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
 
-        clip_with_record_framerate = schema.Clip(clip)
-        clip_with_record_framerate.source_range = opentime.TimeRange(
+        clip_with_timeline_framerate = copy.deepcopy(clip)
+        clip_with_timeline_framerate.source_range = opentime.TimeRange(
                 start_time=opentime.RationalTime(clip.source_range.start_time.value, rate=rate),
                 duration=opentime.RationalTime(clip.source_range.duration.value, rate=rate))
 
-        trimmed_range = clip_with_record_framerate.trimmed_range()
-        range_in_timeline = clip_with_record_framerate.transformed_time_range(
+        trimmed_range = clip_with_timeline_framerate.trimmed_range()
+        range_in_timeline = clip_with_timeline_framerate.transformed_time_range(
             trimmed_range,
             tracks
         )

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1034,12 +1034,14 @@ class Event:
                 line.source_out = (
                     line.source_in + opentime.RationalTime(value, rate))
 
-        trimmed_range_edl_framerate = opentime.TimeRange(
-                start_time=opentime.RationalTime(clip.trimmed_range().start_time.value, rate=rate),
-                duration=opentime.RationalTime(clip.trimmed_range().duration.value, rate=rate)
-        )
-        range_in_timeline = clip.transformed_time_range(
-            trimmed_range_edl_framerate,
+        clip_with_record_framerate = schema.Clip(clip)
+        clip_with_record_framerate.source_range = opentime.TimeRange(
+                start_time=opentime.RationalTime(clip.source_range.start_time.value, rate=rate),
+                duration=opentime.RationalTime(clip.source_range.duration.value, rate=rate))
+
+        trimmed_range = clip_with_record_framerate.trimmed_range()
+        range_in_timeline = clip_with_record_framerate.transformed_time_range(
+            trimmed_range,
             tracks
         )
 


### PR DESCRIPTION
Previous merge doesn't work with all new tests. Reverts to fully functioning version.