### PR TITLE
Remove check for non-STMPE framerates

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -498,15 +498,19 @@ RationalTime::to_timecode(
     double error_margin = nearest_smpte_rate * 0.0005;
     if (std::abs(nearest_smpte_rate - rate) > error_margin)
     {
-        if (error_status)
-        {
-            *error_status = ErrorStatus(ErrorStatus::INVALID_TIMECODE_RATE);
-        }
-        return std::string();
-    }
+        // Dewey - disabled error for non-SMPTE
 
-    // Let's assume this is the rate instead of the given rate.
-    rate = nearest_smpte_rate;
+        // if (error_status)
+        // {
+        //     *error_status = ErrorStatus(ErrorStatus::INVALID_TIMECODE_RATE);
+        // }
+        // return std::string();
+    }
+    else 
+    {
+        // Let's assume this is the rate instead of the given rate.
+        rate = nearest_smpte_rate;
+    }
 
     bool rate_is_dropframe = is_dropframe_rate(rate);
     if (drop_frame == IsDropFrameRate::ForceYes and not rate_is_dropframe)

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -460,15 +460,15 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(ValueError):
             otio.opentime.from_time_string("bogus", 24)
 
-    def test_invalid_rate_to_timecode_functions(self):
-        # Use a bogus rate, expecting `to_timecode` to complain
+    def test_non_smpte_rate_to_timecode_functions(self):
+        # Non-SMPTE rates should produce valid timecodes
         t = otio.opentime.RationalTime(100, 999)
 
-        with self.assertRaises(ValueError):
-            otio.opentime.to_timecode(t, 777)
+        tc1 = otio.opentime.to_timecode(t, 777)
+        self.assertEqual(tc1, "00:00:00:077")
 
-        with self.assertRaises(ValueError):
-            otio.opentime.to_timecode(t)
+        tc2 = otio.opentime.to_timecode(t)
+        self.assertEqual(tc2, "00:00:00:100")
 
     def test_time_string_24(self):
 


### PR DESCRIPTION
## Background
The OTIO rationaltime conversions limit inputs to only valid STMPE frame rates. However, we need the capability to function with any frame rate, including unusual rates from slow-motion cameras or other systems.
By removing the error that is thrown if invalid frame rates are used, we can increase support to all frame rates.

## Changes
Remove the check in rationalTime conversions that throws an error if the provided frame rate is not in the list of STMPE frame rates. The list is still used to round to the nearest timecode to provide support for shorthanding drop-frame rates.

## Testing Done
Automated testing